### PR TITLE
Auto select while quick match matches?

### DIFF
--- a/autoload/neocomplcache.vim
+++ b/autoload/neocomplcache.vim
@@ -573,10 +573,10 @@ function! neocomplcache#do_auto_complete(is_moved)"{{{
 
       " Set function.
       let &l:completefunc = 'neocomplcache#auto_complete'
-      if neocomplcache#is_auto_select()
+      "if neocomplcache#is_auto_select()
         call feedkeys("\<Plug>(neocomplcache_start_auto_select_complete)")
-      else
-        call feedkeys("\<Plug>(neocomplcache_start_auto_complete)")
+      "else
+        "call feedkeys("\<Plug>(neocomplcache_start_auto_complete)")
       endif
       let s:old_cur_text = l:cur_text
       return


### PR DESCRIPTION
I just comment these lines to get the auto_select effect while quick match.

You may add an option: 
 quick_match_with_auto_select

And , I think the  behaviro should be 
not only select , but also set the current word to the selection.
because there is only 1 match there.
so the option may be  **quick_match_auto_select_and_set** ??
