### PR TITLE
filename_completionの~/の問題の修正

### DIFF
--- a/autoload/neocomplcache/sources/filename_complete.vim
+++ b/autoload/neocomplcache/sources/filename_complete.vim
@@ -224,7 +224,7 @@ function! s:get_glob_files(cur_keyword_str, path)"{{{
     endif
 
     let l:abbr = l:dict.word
-    if isdirectory(l:dict.word)
+    if isdirectory(expand(l:dict.word))
       let l:abbr .= '/'
       if g:neocomplcache_enable_auto_delimiter
         let l:dict.word .= '/'


### PR DESCRIPTION
```
$ ~/
/Users/ujihisa/hello.vim
....
```

みたいに~/がフルパスに展開されてしまうのを直しました。

ユーザが明示的にフルパスを指定したときも、逆に畳み込んだりしないようにしています。
