### PR TITLE
bugfix: filename completion failed to check if a path was a directory if it had `~/` 

### DIFF
--- a/autoload/neocomplcache/sources/filename_complete.vim
+++ b/autoload/neocomplcache/sources/filename_complete.vim
@@ -224,7 +224,7 @@ function! s:get_glob_files(cur_keyword_str, path)"{{{
     endif
 
     let l:abbr = l:dict.word
-    if isdirectory(l:dict.word)
+    if isdirectory(expand(l:dict.word))
       let l:abbr .= '/'
       if g:neocomplcache_enable_auto_delimiter
         let l:dict.word .= '/'


### PR DESCRIPTION
- before http://gyazo.com/b93d9664c58d9039569562f92d01928e.png
- after http://gyazo.com/e0d94b495bc43753fdf49270d2c777cb.png
