### PR TITLE
rubyにちょっぴりsnippet追加

### DIFF
--- a/autoload/neocomplcache/sources/snippets_complete/ruby.snip
+++ b/autoload/neocomplcache/sources/snippets_complete/ruby.snip
@@ -38,3 +38,7 @@ snippet     edn
 abbr        => end?
     end
 
+snippet     urlencode
+    # coding: utf-8
+    require 'erb'
+    puts ERB::Util.url_encode '${1}'


### PR DESCRIPTION
- It's confuging that you can't encode url by URL.encode but by ERB::Util.url_encode
- People usually just copy the snippet and paste it
