### PR TITLE
Fix doc g:neocomplcache_cursor_hold_i_time duplication

### DIFF
--- a/doc/neocomplcache.txt
+++ b/doc/neocomplcache.txt
@@ -285,11 +285,6 @@ g:neocomplcache_enable_auto_delimiter		*g:neocomplcache_enable_auto_delimiter*
 		
 		Default value is 0.
 
-g:neocomplcache_cursor_hold_i_time		*g:neocomplcache_cursor_hold_i_time*
-		This variable defines time of automatic completion by a milli second unit.
-		
-		Default value is 300.
-
 g:neocomplcache_enable_camel_case_completion	*g:neocomplcache_enable_camel_case_completion*
 		When you input a capital letter, this variable controls
 		whether neocomplcache takes an ambiguous searching as an end


### PR DESCRIPTION
ドキュメントの `g:neocomplcache_cursor_hold_i_time` が重複している事で、Pathogen を利用している際に以下のようなエラーが出ます。

``` bash
$ vim neocomplcache.txt 
function pathogen#helptags の処理中にエラーが検出されました:
行    3:
E154: タグ "g:neocomplcache_cursor_hold_i_time" がファイル /Users/heavenshell/.vim/bundle/neocomplcache/doc/neocomplcache.txt に重複しています
続けるにはENTERを押すかコマンドを入力してください
```

https://github.com/Shougo/neocomplcache/commit/949553b1446a439b0ca85a67e183a18ad601ef1a#L1R259 この変更が原因かと思います。
既にあった g:neocomplcache_cursor_hold_i_time の項目を削除しました。
