### PR TITLE
Add g:neocomplcache_ignore_composite_filetype_lists option

### DIFF
--- a/autoload/neocomplcache.vim
+++ b/autoload/neocomplcache.vim
@@ -1,7 +1,7 @@
 "=============================================================================
 " FILE: neocomplcache.vim
 " AUTHOR:  Shougo Matsushita <Shougo.Matsu@gmail.com>
-" Last Modified: 10 Jun 2012.
+" Last Modified: 15 Jun 2012.
 " License: MIT license  {{{
 "     Permission is hereby granted, free of charge, to any person obtaining
 "     a copy of this software and associated documentation files (the
@@ -490,6 +490,12 @@ function! neocomplcache#enable() "{{{
   endif
   call neocomplcache#set_dictionary_helper(g:neocomplcache_tags_filter_patterns, 'c,cpp', 
         \'v:val.word !~ ''^[~_]''')
+  "}}}
+
+  " Initialize ignore composite filetypes
+  if !exists('g:neocomplcache_ignore_composite_filetype_lists')
+    let g:neocomplcache_ignore_composite_filetype_lists = {}
+  endif
   "}}}
 
   " Add commands."{{{
@@ -1279,8 +1285,12 @@ function! neocomplcache#get_source_filetypes(filetype)"{{{
 
   let filetypes = [filetype]
   if filetype =~ '\.'
-    " Set compound filetype.
-    let filetypes += split(filetype, '\.')
+    if has_key(g:neocomplcache_ignore_composite_filetype_lists, filetype)
+      let filetypes = [g:neocomplcache_ignore_composite_filetype_lists[filetype]]
+    else
+      " Set compound filetype.
+      let filetypes += split(filetype, '\.')
+    endif
   endif
 
   for ft in filter(copy(filetypes),

--- a/doc/neocomplcache.txt
+++ b/doc/neocomplcache.txt
@@ -706,6 +706,23 @@ g:neocomplcache_use_vimproc			*g:neocomplcache_use_vimproc*
 		
 		Default value is vimproc auto detection result.
 
+g:neocomplcache_ignore_composite_filetype_lists	*g:neocomplcache_ignore_composite_filetype_lists*
+		It is a dictionary to ignore composite file type.
+		The dictionary's key is composite filetype and value is
+		filetype.
+		Ex:
+>
+		let g:neocomplcache_ignore_composite_filetype_lists = {
+			\ 'ruby.spec' : 'ruby'
+			\ }
+<
+		If you open filetype like |ruby.spec|, completion is
+		intended for |ruby| and |spec|.
+		But if you only want to complete |ruby| filetype,
+		you can set this variable to ignore |spec|.
+		
+		Default value is {}.
+
 ------------------------------------------------------------------------------
 KEY MAPPINGS 					*neocomplcache-key-mappings*
 


### PR DESCRIPTION
こんにちは。

filetype が複数ある場合以下の現象が発生しました。
1. Vim を起動する
2. ユニットテストのファイルを開き(https://github.com/heavenshell/tddbc-osaka/blob/master/test_vendingmachine.py を使用して確認しました)、`set ft=python.unit` と設定する
3. 初回起動時に `def` というキーワードを入力する

補完が起動し終わるまでの速度を計測しました。

計測方法は autoload/neocomplcache.vim の `function! s:do_auto_complete(event)` の直後に

``` viml
let start = reltime()
```

`endfunction` の直前に

``` viml
echomsg string(reltimestr(reltime(start)))
```

と埋め込んで確認しました。

| python.unit | python |
| --- | --- |
| 5.028276 sec | 1.874612 sec |

複数の filetype がある場合、起動直後の補完実行が一つの場合に比べて格段に遅くなってます。

ソースコードを確認した所、`python.unit` のような filetype の場合、`python.unit`, `python`, `unit` でそれぞれキャッシュから補完を取得しようとしています。

この場合 `python` だけで良いので、以下のように新しいオプションを提案させて頂きます。

``` viml
let g:neocomplcache_ignore_composite_filetype_lists = {
  \ 'python.unit': 'python',
  \}
```

キーに複合 filetype、値に処理して欲しい filetype を設定する事で、ループを回る回数を抑制します。
(設定しない場合は、現状通りの動作です)

パッチ適応後に計測

| python.unit | python |
| --- | --- |
| 1.874612 sec | 1.902553 sec |

複数の filetype がある場合でも単一の filetype と同等の速度に改善されます。

また、複数の filetype の場合と単一の filetype の場合は補完候補数が異なりました。
これは `unit` という filetype を読み込んでる事から仕様かもしれませんが…。

`filetype=python.unit` で `def` と入力した場合

```
    def                  <Snip> def function(...): ...                          
    default_amount     v [I] test_vendingmac VendorMachine                      
    deff                 <Snip> def ${1:fname}(${2:`indent('.') ? 'self'..):  ${
    defm                 <Snip> def method(self, ...): ...                      
    defs                 <Snip> def ${1:mname}(self, ${2:arg}):  ${3:pass}      
    defConv              [D] complete-dict                                      
    def_prog_mode        [D] complete-dict                                      
    def_shell_mode       [D] complete-dict                                      
    default              [D] complete-dict                                      
    defaultContextDict   [D] complete-dict
    -- ユーザ定義補完 (^U^N^P) 1 番目の該当 (全該当 37 個中)
```

`filetype=python` で `def` と入力した場合

```
    def                                <Snip> def function(...): ...            
    defaultTestLoader = TestLoader() v [I] unittest.py                          
    def defaultTestResult(self):     m [I] unittest.py TestCase                 
    default_amount                   v [I] test_vendingmac VendorMachine        
    deff                               <Snip> def ${1:fname}(${2:`indent('.') ? 
    defm                               <Snip> def method(self, ...): ...        
    defs                               <Snip> def ${1:mname}(self, ${2:arg}):  $
    defConv                            [D] complete-dict                        
    def_prog_mode                      [D] complete-dict                        
    def_shell_mode                     [D] complete-dict                        
    default                            [D] complete-dict                        
    defaultContextDict                 [D] complete-dict                        
    defaultErrorHandler                [D] complete-dict                        
    defaultFactoryMethod               [D] complete-dict                        
    defaultHeadersFilter               [D] complete-dict                        
    defaultObserver                    [D] complete-dict                        
    defaultPortForScheme               [D] complete-dict                        
    default_action                     [D] complete-dict                        
    default_association_order          [D] complete-dict                        
    default_bufsize                    [D] complete-dict                        
    default_int_handler                [D] complete-dict                        
    default_negotiator                 [D] complete-dict                        
    default_number                     [D] complete-dict                        
    default_repeat                     [D] complete-dict                        
    default_timer                      [D] complete-dict                        
    defaultaction                      [D] complete-dict                        
    defaultdict                        [D] complete-dict                        
    defer                              [D] complete-dict                        
    deferLater                         [D] complete-dict                        
    deferToThread                      [D] complete-dict                        
    deferToThreadPool                  [D] complete-dict                        
    deferr                             [D] complete-dict                        
    deferredAskFrame                   [D] complete-dict                        
    deferredGenerator                  [D] complete-dict                        
    define                             [D] complete-dict                        
    deflateStream                      [D] complete-dict                        
    deform                             [D] complete-dict                        
    defpath                            [D] complete-dict                        
    defproperty                        [D] complete-dict
-- ユーザ定義補完 (^U^N^P) 1 番目の該当 (全該当 89 個中)
```

この現象もパッチを適応する事により、補完数も同じ数になります。

なお私の neocomplcache 関連の補完は以下の通りです。
https://gist.github.com/2875547
(現在は上記の .vimrc に g:neocomplcache_ignore_composite_filetype_lists を加えてます)
