### PR TITLE
fix typo - init g:neocomplcache_enable_prefetch

### DIFF
--- a/plugin/neocomplcache.vim
+++ b/plugin/neocomplcache.vim
@@ -140,7 +140,7 @@ let g:neocomplcache_ctags_program =
 let g:neocomplcache_force_overwrite_completefunc =
       \ get(g:, 'neocomplcache_force_overwrite_completefunc', 0)
 let g:neocomplcache_enable_prefetch =
-      \ get(g:, 'g:neocomplcache_enable_prefetch',
+      \ get(g:, 'neocomplcache_enable_prefetch',
       \  !(v:version > 703 || v:version == 703 && has('patch519')
       \ ))
 let g:neocomplcache_lock_iminsert =


### PR DESCRIPTION
g:neocomplcache_enable_prefetch の init に typo があり、rcfile の設定が overwrite されていたので修正しました。
