### PR TITLE
Fix s:is_enabled default value

### DIFF
--- a/autoload/neocomplcache.vim
+++ b/autoload/neocomplcache.vim
@@ -55,8 +55,8 @@ function! s:initialize_variables()"{{{
 endfunction"}}}
 
 if !exists('s:is_enabled')
-  let s:is_enabled = 0
   call s:initialize_variables()
+  let s:is_enabled = 0
 endif
 
 function! neocomplcache#enable() "{{{


### PR DESCRIPTION
g:neocomplcache_enable_at_startup=0を設定してVimを起動しても、neocomplcache#is_enabled()を呼ぶと1が返ってきてしまいます。
