### PR TITLE
抜けてたので追記しました

### DIFF
--- a/autoload/neocomplcache/sources/vim_complete/autocmds.dict
+++ b/autoload/neocomplcache/sources/vim_complete/autocmds.dict
@@ -71,6 +71,7 @@ InsertEnter ; starting Insert mode
 InsertChange ; when typing <Insert> while in Insert or Replace mode
 InsertLeave ; when leaving Insert mode
 ColorScheme ; after loading a color scheme
+CompleteDone ; after Insert mode completion is done
 RemoteReply ; a reply from a server Vim was received
 QuickFixCmdPre ; before a quickfix command is run
 QuickFixCmdPost ; after a quickfix command is run


### PR DESCRIPTION
ちなみにこれ、vim本体のdocの抜け落ちが原因と推測。`:h CompleteDone`するとでてくるのに`h autocmd`のとこのイベント一覧には出てこないと。あとでたぶんvim_devで報告します。
