### PR TITLE
Don't echo an error when a message will do

### DIFF
--- a/plugin/neocomplcache.vim
+++ b/plugin/neocomplcache.vim
@@ -28,13 +28,17 @@
 if exists('g:loaded_neocomplcache')
   finish
 elseif v:version < 702
-  echoerr 'neocomplcache does not work this version of Vim (' . v:version . ').'
+  echohl Error
+  echomsg 'neocomplcache does not work this version of Vim (' . v:version . ').'
+  echohl None
   finish
 elseif $SUDO_USER != '' && $USER !=# $SUDO_USER
       \ && $HOME !=# expand('~'.$USER)
       \ && $HOME ==# expand('~'.$SUDO_USER)
-  echoerr '"sudo vim" and $HOME is not same to /root are detected.'
+  echohl Error
+  echomsg '"sudo vim" and $HOME is not same to /root are detected.'
         \.'Please use sudo.vim plugin instead of sudo command or set always_set_home in sudoers.'
+  echohl None
   finish
 endif
 


### PR DESCRIPTION
`:echoerr` in a script gives users the impression something is wrong 

```
Error detected while processing /path/to/file.vim:
line    1:
your message here
```

It's fine to use in maps because the script name and line number aren't displayed.
