### PR TITLE
Fixed truncate_smart() deprecation warning

### DIFF
--- a/autoload/neocomplcache/util.vim
+++ b/autoload/neocomplcache/util.vim
@@ -32,7 +32,7 @@ let s:List = vital#of('neocomplcache').import('Data.List')
 let s:String = vital#of('neocomplcache').import('Data.String')
 
 function! neocomplcache#util#truncate_smart(...) "{{{
-  return call(s:V.truncate_smart, a:000)
+  return call(s:V.truncate_skipping, a:000)
 endfunction"}}}
 
 function! neocomplcache#util#truncate(...) "{{{


### PR DESCRIPTION
`if_lua` が使えない Vim では neocomplcache を使っているのですが，補完実行のたびに `:message` に警告が出ていることに気づきました．

```
function neocomplcache#complete#auto_complete..neocomplcache#complete#manual_complete..neocomplcache#complete#_get_words..neocomplcache#helper#call_filters..101..neocomplcache#util#truncate_smart..<SNR>136_truncate_smart,  line 1
Vim(echoerr):Prelude.truncate_smart() is obsolete. Use its truncate_skipping() instead; they are equivalent.
[unite.vim] Error occured in calling filter converter_abbr!
[unite.vim] Source name is vim_complete
```

`Vital.Prelude` 内での deprecation error だったので，修正してみました．
