### PR TITLE
Prefer XDG_CACHE_HOME over ~/.cache if set

### DIFF
--- a/doc/neocomplcache.txt
+++ b/doc/neocomplcache.txt
@@ -432,7 +432,8 @@ g:neocomplcache_temporary_dir		*g:neocomplcache_temporary_dir*
 		buffer_complete.vim stores cache of the keyword in this
 		'buffer_cache' sub directory.
 
-		Default value is '~/.cache/neocomplcache'.
+		Default value is "$XDG_CACHE_HOME/neocomplcache" or
+		expand("~/.cache/neocomplcache"); the absolute path of it.
 
 g:neocomplcache_keyword_patterns
 					*g:neocomplcache_keyword_patterns*

--- a/plugin/neocomplcache.vim
+++ b/plugin/neocomplcache.vim
@@ -177,7 +177,9 @@ let g:neocomplcache_source_rank =
       \ get(g:, 'neocomplcache_source_rank', {})
 
 let g:neocomplcache_temporary_dir =
-      \ get(g:, 'neocomplcache_temporary_dir', expand('~/.cache/neocomplcache'))
+      \ get(g:, 'neocomplcache_temporary_dir',
+      \  ($XDG_CACHE_HOME != '' ?
+      \   $XDG_CACHE_HOME . '/neocomplcache' : expand('~/.cache/neocomplcache')))
 let g:neocomplcache_enable_debug =
       \ get(g:, 'neocomplcache_enable_debug', 0)
 if get(g:, 'neocomplcache_enable_at_startup', 0)


### PR DESCRIPTION
Further functionality based on #478

per http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html
